### PR TITLE
Fix multiple words translation

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-es2015-modules-commonjs"]
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,7 +7,10 @@ module.exports = {
   globals: {
     "fetch": false,
     "window": true,
-    "document": true
+    "document": true,
+    "describe": true,
+    "test": true,
+    "expect": true,
   },
   extends: 'eslint:recommended',
   parserOptions: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,9 @@
+// For a detailed explanation regarding each configuration property, visit:
+// https://jestjs.io/docs/en/configuration.html
+
+module.exports = {
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.js$': 'babel-jest'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "lint:css": "stylint ./src/",
     "lint:js": "eslint ./src/",
     "fix:js": "eslint ./src/ --fix",
-    "precommit": "npm run lint"
+    "precommit": "npm run lint",
+    "test": "jest",
+    "test:watch": "jest --watch"
   },
   "gh-pages-deploy": {
     "staticpath": "dist",
@@ -38,6 +40,7 @@
   "devDependencies": {
     "autoprefixer": "^8.2.0",
     "babel-core": "^6.26.0",
+    "babel-jest": "^23.4.2",
     "babel-loader": "^7.1.4",
     "babel-preset-env": "^1.6.0",
     "clean-webpack-plugin": "^0.1.19",
@@ -49,6 +52,7 @@
     "gh-pages-deploy": "^0.4.2",
     "html-webpack-plugin": "^2.30.1",
     "imagemin-webpack-plugin": "^2.1.1",
+    "jest": "^23.4.2",
     "json-loader": "^0.5.7",
     "lost": "^8.2.1",
     "offline-plugin": "^4.9.0",

--- a/src/js/__tests__/translator.js
+++ b/src/js/__tests__/translator.js
@@ -1,0 +1,30 @@
+import { translate } from '../translator';
+
+describe('translate', () => {
+  test('the input with a single word', () => {
+    const library = { 'vossa excelencia': 'mano' };
+    const inputText = 'vossa excelencia';
+
+    expect(translate(library, inputText)).toBe('mano');
+  });
+
+  test('the input with multiple words', () => {
+    const library = {
+      'vossa excelencia': 'mano',
+      'estadista': 'membro da casta mais alta'
+    };
+    const inputText = 'vossa excelencia é um estadista';
+
+    expect(translate(library, inputText)).toBe('mano é um membro da casta mais alta');
+  });
+
+  test('the input with accent words', () => {
+    const library = {
+      'vossa excelência': 'mano',
+      'estadista': 'membro da casta mais alta'
+    };
+    const inputText = 'vossa excelência é um estadista';
+
+    expect(translate(library, inputText)).toBe('mano é um membro da casta mais alta');
+  });
+});

--- a/src/js/translator.js
+++ b/src/js/translator.js
@@ -1,39 +1,36 @@
 import filter from 'lodash/filter';
 import json from '../library.json';
-import { removeAccent } from './convert.js'; 
-import { debounce } from './debounce.js'; 
-import { capitalizeFirstLetter } from './capitalize'; 
+import { debounce } from './debounce.js';
+import { capitalizeFirstLetter } from './capitalize';
 
 const generateRandomKey = (data = []) => Math.floor(Math.random() * (data.length - 0) + 0);
 
 const translate = (library, input) => {
   let text = input;
-  filter(library, (value, key) => { 
-    const regex = new RegExp(removeAccent(key), 'gm');  
-    if (removeAccent(text) === removeAccent(key)) {
-      return text = removeAccent(text).replace(regex, value); 
-    }
-  }); 
+  filter(library, (value, key) => {
+    const regex = new RegExp(key, 'gm');
+    text = text.replace(regex, value);
+  });
   return text;
 };
 
 export const translator = (e) => {
   const $translator = document.querySelector('[data-translator="input"]');
-  const $result = document.querySelector('[data-translator="result"]'); 
-  
-  const textTranslate = (e) => { 
+  const $result = document.querySelector('[data-translator="result"]');
+
+  const textTranslate = (e) => {
     let text;
-    text = $translator.value.toLowerCase();  
+    text = $translator.value.toLowerCase();
     if(text === ''){
       $translator.placeholder = 'Digitar texto...';
-      $result.value = 'Tradução'; 
+      $result.value = 'Tradução';
       return;
     }
     text = translate(json, text);
     $result.value = capitalizeFirstLetter(text) || 'Tradução';
     $translator.value = capitalizeFirstLetter($translator.value);
   };
-  
+
   const getRandomText = () => {
     const keys = Object.keys(json);
     const phrase = keys[generateRandomKey(keys)];


### PR DESCRIPTION
## Context

Recent updates prevent multiple words phrases from being translated, take a look:

![image](https://user-images.githubusercontent.com/4405147/43646338-0e516b6c-970b-11e8-8ef0-647b2117e655.png)

## Changes

I've fixed the code, created a test suite using Jest and created some test cases covering some use cases:
- single words translation
- multiple words translation
- translations with accent

Multiple Words | Multiple Translations
-|-
![image](https://user-images.githubusercontent.com/4405147/43646390-30db747a-970b-11e8-9adb-a2e15e660fce.png) | ![image](https://user-images.githubusercontent.com/4405147/43646444-54a2a6a8-970b-11e8-8cf7-e5960104d3d2.png)

