### PR TITLE
Translate unaccented words

### DIFF
--- a/src/js/__tests__/translator.js
+++ b/src/js/__tests__/translator.js
@@ -1,28 +1,20 @@
 import { translate } from '../translator';
+import library from '../../library.json';
 
 describe('translate', () => {
   test('the input with a single word', () => {
-    const library = { 'vossa excelencia': 'mano' };
     const inputText = 'vossa excelencia';
 
     expect(translate(library, inputText)).toBe('mano');
   });
 
   test('the input with multiple words', () => {
-    const library = {
-      'vossa excelencia': 'mano',
-      'estadista': 'membro da casta mais alta'
-    };
-    const inputText = 'vossa excelencia é um estadista';
+    const inputText = 'vossa excelência é um estadista';
 
     expect(translate(library, inputText)).toBe('mano é um membro da casta mais alta');
   });
 
   test('the input with accent words', () => {
-    const library = {
-      'vossa excelência': 'mano',
-      'estadista': 'membro da casta mais alta'
-    };
     const inputText = 'vossa excelência é um estadista';
 
     expect(translate(library, inputText)).toBe('mano é um membro da casta mais alta');

--- a/src/js/__tests__/translator.js
+++ b/src/js/__tests__/translator.js
@@ -19,4 +19,10 @@ describe('translate', () => {
 
     expect(translate(library, inputText)).toBe('mano é um membro da casta mais alta');
   });
+
+  test('the input with unaccented word', () => {
+    const inputText = 'usucapiao';
+
+    expect(translate(library, inputText)).toBe('tomou de assalto');
+  });
 });

--- a/src/js/translator.js
+++ b/src/js/translator.js
@@ -2,16 +2,21 @@ import filter from 'lodash/filter';
 import json from '../library.json';
 import { debounce } from './debounce.js';
 import { capitalizeFirstLetter } from './capitalize';
+import { removeAccent } from './convert';
 
 const generateRandomKey = (data = []) => Math.floor(Math.random() * (data.length - 0) + 0);
 
-const translate = (library, input) => {
-  let text = input;
-  filter(library, (value, key) => {
-    const regex = new RegExp(key, 'gm');
-    text = text.replace(regex, value);
+export const translate = (library, inputText) => {
+  let translatedText = inputText;
+  filter(library, (politicalLanguage, peopleLanguage) => {
+    const peopleLanguageRegex = new RegExp(peopleLanguage, 'gm');
+    const peopleLanguageWithoutAccentRegex = new RegExp(removeAccent(peopleLanguage), 'gm');
+
+    translatedText = translatedText
+      .replace(peopleLanguageRegex, politicalLanguage)
+      .replace(peopleLanguageWithoutAccentRegex, politicalLanguage);
   });
-  return text;
+  return translatedText;
 };
 
 export const translator = (e) => {

--- a/src/library.json
+++ b/src/library.json
@@ -22,7 +22,7 @@
   "prerrogativa": "vantagem que pessoas comuns não tem",
   "promulgação": "publicação",
   "promulgou": "publicou",
-  "vossa excelencia": "mano",
+  "vossa excelência": "mano",
   "legalidade": "dentro da lei",
   "licito": "dentro da lei",
   "lobby": "pressão para influenciar na tomada de decisões",


### PR DESCRIPTION
## What

Translate unaccented words.

#### Before

```js
translate(library, 'usucapião');
// "tomou de assalto"

translate(library, 'usucapiao');
// "usucapiao"
```

#### After

```js
translate(library, 'usucapião');
// "tomou de assalto"

translate(library, 'usucapiao');
// "tomou de assalto"
```

